### PR TITLE
fix: yarn config should not require nohoist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "bndl_cli"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "bndl_convert",
  "bndl_deps",
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "bndl_deps"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "lazy_static",
  "log",

--- a/crates/bndl_cli/Cargo.toml
+++ b/crates/bndl_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bndl_cli"
-version = "1.8.0"
+version = "1.8.1"
 description = "A basic TypeScript transpiling and bundling tool for (primarily backend) monorepos"
 authors = ["Niels Segers <contact@niels.foo>"]
 edition = "2021"
@@ -15,7 +15,7 @@ name = "bndl"
 path = "src/main.rs"
 
 [dependencies]
-bndl_deps = { version = "1.1.1", path = "../bndl_deps" }
+bndl_deps = { version = "1.1.2", path = "../bndl_deps" }
 bndl_convert = { version = "1.3.3", path = "../bndl_convert" }
 clap = "4.4.8"
 env_logger = "0.10.1"

--- a/crates/bndl_convert/Cargo.toml
+++ b/crates/bndl_convert/Cargo.toml
@@ -26,7 +26,7 @@ name = "bndl-convert"
 path = "src/main.rs"
 
 [dependencies]
-bndl_deps = { version = "1.1.1", path = "../bndl_deps" }
+bndl_deps = { version = "1.1.2", path = "../bndl_deps" }
 clap = "4.4.8"
 env_logger = "0.10.1"
 globset = "0.4.13"

--- a/crates/bndl_deps/Cargo.toml
+++ b/crates/bndl_deps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bndl_deps"
-version = "1.1.1"
+version = "1.1.2"
 description = "Internal crate responsible for all internal dependency config resolving"
 authors = ["Niels Segers <contact@niels.foo>"]
 edition = "2021"

--- a/crates/bndl_deps/src/lib.rs
+++ b/crates/bndl_deps/src/lib.rs
@@ -22,7 +22,7 @@ lazy_static! {
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct YarnConfig {
     pub packages: Vec<String>,
-    pub nohoist: Vec<String>,
+    pub nohoist: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
### Description
This PR updates the `bndl_deps` crate to version 1.1.2 and makes corresponding changes in dependent crates. It also modifies the `YarnConfig` struct to make the `nohoist` field optional.

### Changed
- Updated `bndl_deps` version from 1.1.1 to 1.1.2 in `crates/bndl_deps/Cargo.toml`
- Modified `YarnConfig` struct in `crates/bndl_deps/src/lib.rs` to make `nohoist` field optional
- Updated `bndl_cli` version from 1.8.0 to 1.8.1 in `crates/bndl_cli/Cargo.toml`
- Updated `bndl_deps` dependency version to 1.1.2 in `crates/bndl_cli/Cargo.toml`
- Updated `bndl_deps` dependency version to 1.1.2 in `crates/bndl_convert/Cargo.toml`